### PR TITLE
use log::info! instead of println!

### DIFF
--- a/client/src/webrtc_client_socket/mod.rs
+++ b/client/src/webrtc_client_socket/mod.rs
@@ -50,7 +50,7 @@ impl ClientSocketTrait for WebrtcClientSocket {
                     self.message_sender
                         .send(dropped_packet)
                         .unwrap_or_else(|err| {
-                            println!("Can't send dropped packet. Original Error: {:?}", err)
+                            info!("Can't send dropped packet. Original Error: {:?}", err)
                         });
                 }
             }
@@ -196,7 +196,7 @@ fn webrtc_initialize(
             request
                 .open("POST", &server_url_msg_clone)
                 .unwrap_or_else(|err| {
-                    println!(
+                    info!(
                         "WebSys, can't POST to server url. Original Error: {:?}",
                         err
                     )
@@ -279,7 +279,7 @@ fn webrtc_initialize(
                     peer_clone_2.local_description().unwrap().sdp().as_str(),
                 ))
                 .unwrap_or_else(|err| {
-                    println!("WebSys, can't sent request str. Original Error: {:?}", err)
+                    info!("WebSys, can't sent request str. Original Error: {:?}", err)
                 });
         });
         let peer_desc_callback = Closure::wrap(peer_desc_func);

--- a/shared/src/link_condition_logic.rs
+++ b/shared/src/link_condition_logic.rs
@@ -1,3 +1,6 @@
+extern crate log;
+use log::info;
+
 use super::{
     instant::Instant, link_conditioner_config::LinkConditionerConfig, time_queue::TimeQueue,
 };
@@ -12,12 +15,12 @@ pub fn process_packet<T: Eq>(
 ) {
     if gen_range_f32(0.0, 1.0) <= config.incoming_loss {
         // drop the packet
-        println!("link conditioner: packet lost");
+        info!("link conditioner: packet lost");
         return;
     }
     if gen_range_f32(0.0, 1.0) <= config.incoming_corruption {
         //TODO: corrupt the packet
-        println!("link conditioner: packet corrupted");
+        info!("link conditioner: packet corrupted");
         return;
     }
     let mut latency: u32 = config.incoming_latency;


### PR DESCRIPTION
I am using _naia_ in a very limited wasm environment (without stdout support) and link_conditioner panicks on trying to `println!`.

Replacing `println!` with `info!` calls fixes the crash. Also makes it in line with the rest of the code, which uses log crate.