### PR TITLE
Mark ClientSocketTrait Send + Sync when multithreaded

### DIFF
--- a/client/src/client_socket.rs
+++ b/client/src/client_socket.rs
@@ -4,18 +4,36 @@ use naia_socket_shared::LinkConditionerConfig;
 
 use super::{error::NaiaClientSocketError, message_sender::MessageSender, packet::Packet};
 
-/// Defines the functionality of a Naia Client Socket
-pub trait ClientSocketTrait: Debug {
-    /// Receive a new packet from the socket, or a tick event
-    fn receive(&mut self) -> Result<Option<Packet>, NaiaClientSocketError>;
-    /// Gets a MessageSender you can use to send messages through the Server
-    /// Socket
-    fn get_sender(&mut self) -> MessageSender;
-    /// Wraps the current socket in a LinkConditioner
-    fn with_link_conditioner(
-        self: Box<Self>,
-        config: &LinkConditionerConfig,
-    ) -> Box<dyn ClientSocketTrait>;
+cfg_if! {
+    if #[cfg(feature = "multithread")] {
+        /// Defines the functionality of a Naia Client Socket
+        pub trait ClientSocketTrait: Debug + Send + Sync {
+            /// Receive a new packet from the socket, or a tick event
+            fn receive(&mut self) -> Result<Option<Packet>, NaiaClientSocketError>;
+            /// Gets a MessageSender you can use to send messages through the Server
+            /// Socket
+            fn get_sender(&mut self) -> MessageSender;
+            /// Wraps the current socket in a LinkConditioner
+            fn with_link_conditioner(
+                self: Box<Self>,
+                config: &LinkConditionerConfig,
+            ) -> Box<dyn ClientSocketTrait>;
+        }
+    } else {
+        /// Defines the functionality of a Naia Client Socket
+        pub trait ClientSocketTrait: Debug {
+            /// Receive a new packet from the socket, or a tick event
+            fn receive(&mut self) -> Result<Option<Packet>, NaiaClientSocketError>;
+            /// Gets a MessageSender you can use to send messages through the Server
+            /// Socket
+            fn get_sender(&mut self) -> MessageSender;
+            /// Wraps the current socket in a LinkConditioner
+            fn with_link_conditioner(
+                self: Box<Self>,
+                config: &LinkConditionerConfig,
+            ) -> Box<dyn ClientSocketTrait>;
+        }
+    }
 }
 
 cfg_if! {


### PR DESCRIPTION
This is required so `NaiaClientSocket` can be used as a part of Bevy's resource.