### PR TITLE
Make webrtc_client_socket thread "safe"

### DIFF
--- a/client/src/client_socket.rs
+++ b/client/src/client_socket.rs
@@ -33,6 +33,13 @@ cfg_if! {
         pub use crate::webrtc_client_socket::WebrtcClientSocket;
         /// ClientSocket is an alias for a socket abstraction using either UDP or WebRTC for communications
         pub type ClientSocket = WebrtcClientSocket;
+
+        #[allow(unsafe_code)]
+        #[cfg(feature = "multithread")]
+        unsafe impl Send for WebrtcClientSocket {}
+        #[allow(unsafe_code)]
+        #[cfg(feature = "multithread")]
+        unsafe impl Sync for WebrtcClientSocket {}
     }
     else {
         // UDP Client //

--- a/client/src/message_sender.rs
+++ b/client/src/message_sender.rs
@@ -2,10 +2,11 @@ use std::error::Error;
 
 use crate::Packet;
 
+use naia_socket_shared::Ref;
+
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
         use std::collections::VecDeque;
-        use std::{cell::RefCell, rc::Rc};
 
         use web_sys::RtcDataChannel;
 
@@ -13,14 +14,14 @@ cfg_if! {
         #[derive(Clone, Debug)]
         pub struct MessageSender {
             data_channel: RtcDataChannel,
-            dropped_outgoing_messages: Rc<RefCell<VecDeque<Packet>>>
+            dropped_outgoing_messages: Ref<VecDeque<Packet>>
         }
 
         impl MessageSender {
             /// Create a new MessageSender, if supplied with the RtcDataChannel and a reference to a list
             /// of dropped messages
             pub fn new(data_channel: RtcDataChannel,
-                       dropped_outgoing_messages: Rc<RefCell<VecDeque<Packet>>>) -> MessageSender {
+                       dropped_outgoing_messages: Ref<VecDeque<Packet>>) -> MessageSender {
                 MessageSender {
                     data_channel,
                     dropped_outgoing_messages
@@ -30,7 +31,7 @@ cfg_if! {
             /// Send a Packet to the Server
             pub fn send(&mut self, packet: Packet) -> Result<(), Box<dyn Error + Send>> {
                 if let Err(_) = self.data_channel.send_with_u8_array(&packet.payload()) {
-                    self.dropped_outgoing_messages.as_ref().borrow_mut().push_back(packet);
+                    self.dropped_outgoing_messages.borrow_mut().push_back(packet);
                 }
                 Ok(())
             }
@@ -40,8 +41,6 @@ cfg_if! {
         use std::{
             net::{SocketAddr, UdpSocket},
         };
-
-        use naia_socket_shared::Ref;
 
         /// Handles sending messages to the Server for a given Client Socket
         #[derive(Clone, Debug)]

--- a/shared/src/reference.rs
+++ b/shared/src/reference.rs
@@ -1,7 +1,7 @@
 cfg_if! {
     if #[cfg(feature = "multithread")] {
         use std::{
-            ops::Deref,
+            ops::{Deref, DerefMut},
             sync::{Arc, Mutex, MutexGuard},
         };
 
@@ -14,7 +14,13 @@ cfg_if! {
             type Target = T;
 
             fn deref(&self) -> &Self::Target {
-                Deref::deref(&self.inner)
+                &self.inner
+            }
+        }
+
+        impl<'a, T> DerefMut for Guard<'a, T> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.inner
             }
         }
 
@@ -38,6 +44,13 @@ cfg_if! {
                     inner: self.inner.lock().unwrap(),
                 }
             }
+
+            /// Mutably borrows the wrapped value
+            pub fn borrow_mut(&self) -> Guard<T> {
+                Guard {
+                    inner: self.inner.lock().unwrap(),
+                }
+            }
         }
 
         impl<T> Clone for Ref<T> {
@@ -50,7 +63,7 @@ cfg_if! {
 
     } else {
         use std::{
-            cell::{Ref as StdRef, RefCell},
+            cell::{Ref as StdRef, RefMut as StdRefMut, RefCell},
             ops::Deref,
             rc::Rc,
         };
@@ -61,6 +74,19 @@ cfg_if! {
         }
 
         impl<'a, T> Deref for Guard<'a, T> {
+            type Target = T;
+
+            fn deref(&self) -> &Self::Target {
+                Deref::deref(&self.inner)
+            }
+        }
+
+        #[derive(Debug)]
+        pub struct GuardMut<'a, T> {
+            inner: StdRefMut<'a, T>,
+        }
+
+        impl<'a, T> Deref for GuardMut<'a, T> {
             type Target = T;
 
             fn deref(&self) -> &Self::Target {
@@ -87,6 +113,13 @@ cfg_if! {
             pub fn borrow(&self) -> Guard<T> {
                 Guard {
                     inner: self.inner.borrow(),
+                }
+            }
+
+            /// Mutably borrows the wrapped value
+            pub fn borrow_mut(&self) -> GuardMut<T> {
+                GuardMut {
+                    inner: self.inner.borrow_mut(),
                 }
             }
         }


### PR DESCRIPTION
I just got https://github.com/smokku/bevy_networking_turbulence/issues/1 and started investigating.
It turns out there is a bit more work to allow WebRTC client to work in threading-requesting Browser environment. ;)