### PR TITLE
Fix #17 Panic in RtcServer

### DIFF
--- a/demo/server/src/main.rs
+++ b/demo/server/src/main.rs
@@ -8,11 +8,22 @@ use simple_logger;
 use smol::io;
 use std::net::IpAddr;
 
-const SERVER_PORT: u16 = 14191;
+const DEFAULT_SERVER_PORT: u16 = 14191;
 const PING_MSG: &str = "ping";
 const PONG_MSG: &str = "pong";
 
 fn main() -> io::Result<()> {
+    let port: u16 = {
+        let args: Vec<String> = std::env::args().collect();
+        if args.len() > 1 {
+            args[1]
+                .parse()
+                .expect("Argument must be a valid u16 integer")
+        } else {
+            DEFAULT_SERVER_PORT
+        }
+    };
+
     smol::block_on(async {
         simple_logger::init_with_level(log::Level::Info).expect("A logger was already initialized");
 
@@ -22,7 +33,7 @@ fn main() -> io::Result<()> {
         let server_ip_address: IpAddr = "127.0.0.1"
             .parse()
             .expect("couldn't parse input IP address");
-        let current_socket_address = SocketAddr::new(server_ip_address, SERVER_PORT);
+        let current_socket_address = SocketAddr::new(server_ip_address, port);
 
         let mut server_socket = ServerSocket::listen(current_socket_address)
             .await

--- a/server/src/impls/webrtc/server_socket.rs
+++ b/server/src/impls/webrtc/server_socket.rs
@@ -1,7 +1,9 @@
 use std::{
     io::Error as IoError,
-    net::{IpAddr, SocketAddr, TcpListener},
+    net::{IpAddr, SocketAddr, UdpSocket},
 };
+
+use log::debug;
 
 use async_trait::async_trait;
 
@@ -39,6 +41,8 @@ impl ServerSocket {
         let webrtc_listen_port =
             get_available_port(webrtc_listen_ip.to_string().as_str()).expect("no available port");
         let webrtc_listen_addr = SocketAddr::new(webrtc_listen_ip, webrtc_listen_port);
+
+        debug!("Using port {} for webrtc listener", webrtc_listen_addr);
 
         let (to_client_sender, to_client_receiver) = mpsc::channel(CLIENT_CHANNEL_SIZE);
 
@@ -136,8 +140,13 @@ fn get_available_port(ip: &str) -> Option<u16> {
 }
 
 fn port_is_available(ip: &str, port: u16) -> bool {
-    match TcpListener::bind((ip, port)) {
-        Ok(_) => true,
+    debug!("Trying to bind to {} {}", ip, port);
+    
+    match UdpSocket::bind((ip, port)) {
+        Ok(_) => {
+            debug!("Was able to bind to {} {}", ip, port);
+            true
+        }
         Err(_) => false,
     }
 }


### PR DESCRIPTION
Before attempting to create the RTC listener, check
if we can bind to UDP (not TCP - this is the bug) to
find an available port in the range.

Adds CLI parsing to the demo server. Exercise the
change (from demo/server) with:

`cargo run --features use-webrtc -- 14191`
`cargo run --features use-webrtc -- 14192`

Observe that the first RTC server starts on 8000,
while the second will now start on 8001, instead
of crashing.