### PR TITLE
Add Sync to socket errors

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -7,7 +7,7 @@ pub enum NaiaClientSocketError {
     /// A simple error message
     Message(String),
     /// A wrapped error from another library/codebase
-    Wrapped(Box<dyn Error + Send>),
+    Wrapped(Box<dyn Error + Send + Sync>),
 }
 
 impl fmt::Display for NaiaClientSocketError {

--- a/client/src/impls/miniquad/message_sender.rs
+++ b/client/src/impls/miniquad/message_sender.rs
@@ -15,7 +15,7 @@ impl MessageSender {
     }
 
     /// Send a Packet to the Server
-    pub fn send(&mut self, packet: Packet) -> Result<(), Box<dyn Error + Send>> {
+    pub fn send(&mut self, packet: Packet) -> Result<(), Box<dyn Error + Send + Sync>> {
         unsafe {
             let payload: &[u8] = packet.payload();
             let ptr = payload.as_ptr();

--- a/client/src/impls/native/message_sender.rs
+++ b/client/src/impls/native/message_sender.rs
@@ -19,7 +19,7 @@ impl MessageSender {
     }
 
     /// Send a Packet to the Server
-    pub fn send(&mut self, packet: Packet) -> Result<(), Box<dyn Error + Send>> {
+    pub fn send(&mut self, packet: Packet) -> Result<(), Box<dyn Error + Send + Sync>> {
         //send it
         if let Err(err) = self
             .socket

--- a/client/src/impls/wasm_bindgen/message_sender.rs
+++ b/client/src/impls/wasm_bindgen/message_sender.rs
@@ -26,7 +26,7 @@ impl MessageSender {
     }
 
     /// Send a Packet to the Server
-    pub fn send(&mut self, packet: Packet) -> Result<(), Box<dyn Error + Send>> {
+    pub fn send(&mut self, packet: Packet) -> Result<(), Box<dyn Error + Send + Sync>> {
         if let Err(_) = self.data_channel.send_with_u8_array(&packet.payload()) {
             self.dropped_outgoing_messages
                 .borrow_mut()

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -5,7 +5,7 @@ use std::{error::Error, fmt, net::SocketAddr};
 #[derive(Debug)]
 pub enum NaiaServerSocketError {
     /// A wrapped error from another library/codebase
-    Wrapped(Box<dyn Error>),
+    Wrapped(Box<dyn Error + Send + Sync>),
     /// An error indicating an inability to send to the given address
     SendError(SocketAddr),
 }

--- a/server/src/message_sender.rs
+++ b/server/src/message_sender.rs
@@ -20,7 +20,7 @@ impl MessageSender {
     }
 
     /// Send a Packet to a client
-    pub async fn send(&mut self, packet: Packet) -> Result<(), Box<dyn Error + Send>> {
+    pub async fn send(&mut self, packet: Packet) -> Result<(), Box<dyn Error + Send + Sync>> {
         match self.internal.send(packet).await {
             Ok(content) => Ok(content),
             Err(error) => {


### PR DESCRIPTION
Hi! Thanks for developing this library.

I have a question (probably a stupid one): is there any specific reason why `Wrapped` variants of `NaiaClientSocketError` and `NaiaServerSocketError` don't contain `Box<dyn Error + Send + Sync>`?

I'm trying to pass the errors returned by naia to things that require this trait, but it obviously fails. I hope this change makes sense and doesn't break anything (so far it seems to compile).