### PR TITLE
Make it possible to pass public address to the server

### DIFF
--- a/server/src/impls/udp/server_socket.rs
+++ b/server/src/impls/udp/server_socket.rs
@@ -4,7 +4,7 @@ use futures_channel::mpsc;
 use futures_util::{pin_mut, select, FutureExt, StreamExt};
 use std::{
     io::Error as IoError,
-    net::{SocketAddr, UdpSocket},
+    net::{IpAddr, SocketAddr, UdpSocket},
 };
 
 use naia_socket_shared::LinkConditionerConfig;
@@ -27,8 +27,11 @@ pub struct ServerSocket {
 
 impl ServerSocket {
     /// Returns a new ServerSocket, listening at the given socket address
-    pub async fn listen(socket_address: SocketAddr) -> Box<dyn ServerSocketTrait> {
-        let socket = Async::new(UdpSocket::bind(&socket_address).unwrap()).unwrap();
+    pub async fn listen(
+        listen_address: SocketAddr,
+        _public_ip_addr: IpAddr,
+    ) -> Box<dyn ServerSocketTrait> {
+        let socket = Async::new(UdpSocket::bind(&listen_address).unwrap()).unwrap();
 
         let (to_client_sender, to_client_receiver) = mpsc::channel(CLIENT_CHANNEL_SIZE);
 

--- a/server/src/impls/webrtc/server_socket.rs
+++ b/server/src/impls/webrtc/server_socket.rs
@@ -36,17 +36,21 @@ pub struct ServerSocket {
 
 impl ServerSocket {
     /// Returns a new ServerSocket, listening at the given socket address
-    pub async fn listen(socket_address: SocketAddr) -> Box<dyn ServerSocketTrait> {
-        let webrtc_listen_ip: IpAddr = socket_address.ip();
+    pub async fn listen(
+        listen_address: SocketAddr,
+        public_ip_addr: IpAddr,
+    ) -> Box<dyn ServerSocketTrait> {
+        let webrtc_listen_ip: IpAddr = listen_address.ip();
         let webrtc_listen_port =
             get_available_port(webrtc_listen_ip.to_string().as_str()).expect("no available port");
         let webrtc_listen_addr = SocketAddr::new(webrtc_listen_ip, webrtc_listen_port);
+        let webrtc_public_address = SocketAddr::new(public_ip_addr, webrtc_listen_port);
 
         debug!("Using port {} for webrtc listener", webrtc_listen_addr);
 
         let (to_client_sender, to_client_receiver) = mpsc::channel(CLIENT_CHANNEL_SIZE);
 
-        let rtc_server = RtcServer::new(webrtc_listen_addr).await;
+        let rtc_server = RtcServer::new(webrtc_listen_addr, webrtc_public_address).await;
 
         let socket = ServerSocket {
             rtc_server,
@@ -54,7 +58,7 @@ impl ServerSocket {
             to_client_receiver,
         };
 
-        start_session_server(socket_address, socket.rtc_server.session_endpoint());
+        start_session_server(listen_address, socket.rtc_server.session_endpoint());
 
         Box::new(socket)
     }
@@ -141,7 +145,7 @@ fn get_available_port(ip: &str) -> Option<u16> {
 
 fn port_is_available(ip: &str, port: u16) -> bool {
     debug!("Trying to bind to {} {}", ip, port);
-    
+
     match UdpSocket::bind((ip, port)) {
         Ok(_) => {
             debug!("Was able to bind to {} {}", ip, port);
@@ -156,8 +160,8 @@ struct RtcServer {
 }
 
 impl RtcServer {
-    pub async fn new(address: SocketAddr) -> RtcServer {
-        let inner = InnerRtcServer::new(address, address)
+    pub async fn new(listen_addr: SocketAddr, public_address: SocketAddr) -> RtcServer {
+        let inner = InnerRtcServer::new(listen_addr, public_address)
             .await
             .expect("could not start RTC server");
 


### PR DESCRIPTION
I've just tried deploying my WebRTC application to AWS and realized that it's impossible to connect any client to it.

I can either bind my socket to `0.0.0.0` or to my private address. But it doesn't work since my server is only accessible if clients connect using a public address, which obviously differs from the one in the private network. And in AWS instances it's impossible to bind a socket to a public address.

`webrtc-unreliable`'s `Server` accepts two parameters: `listen_addr` and `public_ip_addr`, to allow the WebRTC server to respond with a public address of a peer (the server itself in our case). But at the moment `naia-socket` just passes the same value to both parameters.

This PR introduces a breaking change by adding a new `public_ip_addr` parameter to the `listen` function.