### PR TITLE
Fix Firefox support in webrtc request callback

### DIFF
--- a/client/src/impls/wasm_bindgen/webrtc_internal.rs
+++ b/client/src/impls/wasm_bindgen/webrtc_internal.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::{prelude::*, JsCast, JsValue};
 use web_sys::{
     ErrorEvent, MessageEvent, ProgressEvent, RtcConfiguration, RtcDataChannel, RtcDataChannelInit,
     RtcDataChannelType, RtcIceCandidate, RtcIceCandidateInit, RtcPeerConnection, RtcSdpType,
-    RtcSessionDescription, RtcSessionDescriptionInit, XmlHttpRequest,
+    RtcSessionDescriptionInit, XmlHttpRequest,
 };
 
 #[derive(Deserialize, Debug, Clone)]
@@ -101,7 +101,7 @@ pub fn webrtc_initialize(
     let peer_clone = peer.clone();
     let server_url_msg = Ref::new(server_url_str);
     let peer_offer_func: Box<dyn FnMut(JsValue)> = Box::new(move |e: JsValue| {
-        let session_description = e.dyn_into::<RtcSessionDescription>().unwrap();
+        let session_description = e.into();
         let peer_clone_2 = peer_clone.clone();
         let server_url_msg_clone = server_url_msg.clone();
         let peer_desc_func: Box<dyn FnMut(JsValue)> = Box::new(move |_: JsValue| {
@@ -198,11 +198,8 @@ pub fn webrtc_initialize(
         });
         let peer_desc_callback = Closure::wrap(peer_desc_func);
 
-        let mut session_description_init: RtcSessionDescriptionInit =
-            RtcSessionDescriptionInit::new(session_description.type_());
-        session_description_init.sdp(session_description.sdp().as_str());
         peer_clone
-            .set_local_description(&session_description_init)
+            .set_local_description(&session_description)
             .then(&peer_desc_callback);
         peer_desc_callback.forget();
     });


### PR DESCRIPTION
Fixes a nasty panic in Firefox:

```
panicked at 'called `Result::unwrap()` on an `Err` value: JsValue(Object({"type":"offer","sdp":"v=0\r\no=mozilla...THIS_IS_SDPARTA-86.0 628639811215197811 0 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\na=fingerprint:sha-256 CF:3A:78:ED:7D:1F:10:86:C2:DE:CC:D2:C6:31:D7:D4:F9:21:65:8D:A5:AD:12:09:59:1D:A7:94:AD:BB:54:4A\r\na=group:BUNDLE 0\r\na=ice-options:trickle\r\na=msid-semantic:WMS *\r\nm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\nc=IN IP4 0.0.0.0\r\na=sendrecv\r\na=ice-pwd:d090565db93db865cec347818607f3ba\r\na=ice-ufrag:7074cfaf\r\na=mid:0\r\na=setup:actpass\r\na=sctp-port:5000\r\na=max-message-size:1073741823\r\n"}))', C:\Users\mvlabat\.cargo\git\checkouts\naia-socket-333addd872c4cece\4956f91\client\src\impls\wasm_bindgen\webrtc_internal.rs:104:73

Stack:

init/imports.wbg.__wbg_new_59cb74e423758ede@http://muddle.run/pkg/mr_web_client.js:420:19
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[4202]:0x50612a
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[16303]:0x6ea9da
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[7766]:0x632757
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[9272]:0x66f5a4
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[13557]:0x6dbaf9
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[13184]:0x6d6ff9
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[13559]:0x6dbb5d
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[10876]:0x6a178a
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[5548]:0x594f22
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[13963]:0x6df904
__wbg_adapter_36@http://muddle.run/pkg/mr_web_client.js:222:10
real@http://muddle.run/pkg/mr_web_client.js:199:20
promise callback*init/imports.wbg.__wbg_then_dd3785597974798a@http://muddle.run/pkg/mr_web_client.js:1153:35
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[15560]:0x6e86c7
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[1956]:0x3a0f1c
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[4574]:0x5317a5
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[3948]:0x4e7a43
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[839]:0x224efd
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[4825]:0x54d84f
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[16019]:0x6e9e40
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[7049]:0x609b91
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[255]:0x36c5b
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[6533]:0x5e7219
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[257]:0x3da0d
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[2355]:0x3f5e5b
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[2285]:0x3e825c
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[5882]:0x5b2cc5
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[8468]:0x651d6b
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[11154]:0x6a9a77
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[13635]:0x6dc80c
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[13636]:0x6dc834
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[1608]:0x343f0a
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[14054]:0x6e03da
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[5570]:0x597116
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[595]:0x19f299
@http://muddle.run/pkg/mr_web_client.js line 338 > WebAssembly.instantiate:wasm-function[16310]:0x6eaa21
init@http://muddle.run/pkg/mr_web_client.js:1322:10
async*@http://muddle.run/:20:9
```