### PR TITLE
Fix a cyclic dependency caused by wasm-bindgen's serde-serialize feature

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 maintenance = { status = "actively-developed" }
 
 [features]
-wbindgen = [ "naia-socket-shared/wbindgen", "url", "wasm-bindgen", "js-sys", "web_sys", "serde", "serde_derive" ]
+wbindgen = [ "naia-socket-shared/wbindgen", "url", "wasm-bindgen", "js-sys", "web_sys", "serde", "serde_derive", "serde_json" ]
 mquad = [ "naia-socket-shared/mquad", "miniquad" ]
 
 [dependencies]
@@ -24,7 +24,7 @@ naia-socket-shared = { path = "../shared", version = "=0.7.0" }
 cfg-if = "0.1.10"
 log = { version = "0.4" }
 url = { version = "2.1.1", optional = true }
-wasm-bindgen = { version = "0.2.45", features = [ "serde-serialize" ], optional = true  }
+wasm-bindgen = { version = "0.2.68", optional = true  }
 js-sys = { version = "0.3", optional = true  }
 web_sys = { version = "0.3.22", package = "web-sys", features = [
     "RtcDataChannel", "RtcDataChannelInit", "RtcDataChannelType",
@@ -33,4 +33,5 @@ web_sys = { version = "0.3.22", package = "web-sys", features = [
     "XmlHttpRequest", "XmlHttpRequestEventTarget", "MessageEvent", "ProgressEvent", "ErrorEvent", "Blob" ], optional = true  }
 serde = { version = "^1.0.59", optional = true  }
 serde_derive = { version = "^1.0.59", optional = true  }
+serde_json = { version = "^1.0.59", optional = true }
 miniquad = { version = "=0.3.0-alpha.28", features = ["log-impl"], optional = true }

--- a/client/src/impls/wasm_bindgen/webrtc_internal.rs
+++ b/client/src/impls/wasm_bindgen/webrtc_internal.rs
@@ -111,9 +111,7 @@ pub fn webrtc_initialize(
             let request_func: Box<dyn FnMut(ProgressEvent)> = Box::new(move |_: ProgressEvent| {
                 if request_2.status().unwrap() == 200 {
                     let response_string = request_2.response_text().unwrap().unwrap();
-                    let response_js_value = js_sys::JSON::parse(response_string.as_str()).unwrap();
-                    let session_response: JsSessionResponse =
-                        response_js_value.into_serde().unwrap();
+                    let session_response: JsSessionResponse = serde_json::from_str(response_string.as_str()).unwrap();
                     let session_response_answer: SessionAnswer = session_response.answer.clone();
 
                     let peer_clone_4 = peer_clone_3.clone();


### PR DESCRIPTION
Hi!

I've stumbled upon a cyclic dependency when using `naia-socket` together with `sqlx` in my workspace.

```
error: cyclic package dependency: package `js-sys v0.3.46` depends on itself. Cycle:
package `js-sys v0.3.46`
    ... which satisfies dependency `js-sys = "^0.3"` of package `getrandom v0.2.3`
    ... which satisfies dependency `getrandom = "^0.2.3"` of package `ahash v0.7.6`
    ... which satisfies dependency `ahash = "^0.7.0"` of package `hashbrown v0.11.2`
    ... which satisfies dependency `hashbrown = "^0.11"` of package `indexmap v1.7.0`
    ... which satisfies dependency `indexmap = "^1.5"` of package `serde_json v1.0.73`
    ... which satisfies dependency `serde_json = "^1.0"` of package `wasm-bindgen v0.2.69`
    ... which satisfies dependency `wasm-bindgen = "^0.2.69"` of package `js-sys v0.3.46`
    ... which satisfies dependency `js-sys = "^0.3"` of package `instant v0.1.12`
    ... which satisfies dependency `instant = "^0.1.9"` of package `parking_lot v0.11.2`
    ... which satisfies dependency `parking_lot = "^0.11.0"` of package `tokio v1.15.0`
    ... which satisfies dependency `tokio = "^1.5.1"` of package `actix-codec v0.4.1`
```

It's caused by `wasm-bindgen`'s `serde-serialize` feature: https://github.com/tkaitchuck/aHash/issues/95#issuecomment-881503355. By removing the feature and refactoring the code that relied on it with `serde_json`, I was able to fix the error.

I hope that adding `serde_json` to the WASM target as a dependency doesn't make the build much heavier. I haven't been able to find any better workaround for this.