### PR TITLE
Fixes for Safari

### DIFF
--- a/client/src/impls/wasm_bindgen/packet_sender.rs
+++ b/client/src/impls/wasm_bindgen/packet_sender.rs
@@ -28,7 +28,9 @@ impl PacketSender {
     pub fn send(&mut self, packet: Packet) {
         self.resend_dropped_messages();
 
-        if let Err(_) = self.data_channel.send_with_u8_array(&packet.payload()) {
+        if let Err(err) = self.data_channel.send_with_u8_array(&packet.payload()) {
+            log::info!("error when sending packet: {:?}", err);
+
             self.dropped_outgoing_messages
                 .borrow_mut()
                 .push_back(packet);

--- a/client/src/impls/wasm_bindgen/webrtc_internal.rs
+++ b/client/src/impls/wasm_bindgen/webrtc_internal.rs
@@ -117,7 +117,7 @@ pub fn webrtc_initialize(
                     let session_response_answer: SessionAnswer = session_response.answer.clone();
 
                     let peer_clone_4 = peer_clone_3.clone();
-                    let remote_desc_success_func: Box<dyn FnMut(JsValue)> = Box::new(
+                    let remote_desc_func: Box<dyn FnMut(JsValue)> = Box::new(
                         move |e: JsValue| {
                             let mut candidate_init_dict: RtcIceCandidateInit =
                                 RtcIceCandidateInit::new(
@@ -150,28 +150,18 @@ pub fn webrtc_initialize(
                             peer_add_failure_callback.forget();
                         },
                     );
-                    let remote_desc_success_callback = Closure::wrap(remote_desc_success_func);
-
-                    let remote_desc_failure_func: Box<dyn FnMut(JsValue)> =
-                        Box::new(move |_: JsValue| {
-                            info!(
-                                "Client error during 'setRemoteDescription': TODO, put value here"
-                            );
-                        });
-                    let remote_desc_failure_callback = Closure::wrap(remote_desc_failure_func);
+                    let remote_desc_callback = Closure::wrap(remote_desc_func);
 
                     let mut rtc_session_desc_init_dict: RtcSessionDescriptionInit =
                         RtcSessionDescriptionInit::new(RtcSdpType::Answer);
 
                     rtc_session_desc_init_dict.sdp(session_response_answer.sdp.as_str());
 
-                    peer_clone_3.set_remote_description_with_success_callback_and_failure_callback(
-                        &rtc_session_desc_init_dict,
-                        remote_desc_success_callback.as_ref().unchecked_ref(),
-                        remote_desc_failure_callback.as_ref().unchecked_ref(),
-                    );
-                    remote_desc_success_callback.forget();
-                    remote_desc_failure_callback.forget();
+                    peer_clone_3
+                        .set_remote_description(&rtc_session_desc_init_dict)
+                        .then(&remote_desc_callback);
+
+                    remote_desc_callback.forget();
                 }
             });
             let request_callback = Closure::wrap(request_func);

--- a/server/src/impls/webrtc/session.rs
+++ b/server/src/impls/webrtc/session.rs
@@ -69,28 +69,56 @@ async fn listen(
 async fn serve(mut session_endpoint: SessionEndpoint, mut stream: Arc<Async<TcpStream>>) {
     let remote_addr = stream.get_ref().local_addr().unwrap();
     let mut success: bool = false;
+    let mut headers_read: bool = false;
+    let mut content_length: Option<usize> = None;
+    let mut rtc_url_match = false;
+    let mut body: Vec<u8> = Vec::new();
 
+    let buf_reader = BufReader::new(stream.clone());
+    let mut bytes = buf_reader.bytes();
     {
-        let buf_reader = BufReader::new(stream.clone());
-        let mut lines = buf_reader.lines();
-        {
-            if let Some(line) = lines.next().await {
-                let line = line.unwrap();
-                if line.starts_with(RTC_URL_PATH.get().unwrap()) {
-                    while let Some(line) = lines.next().await {
-                        let line = line.unwrap();
-                        if line.len() == 0 {
-                            success = true;
-                            break;
-                        }
+        let mut line: Vec<u8> = Vec::new();
+        while let Some(byte) = bytes.next().await {
+            let byte = byte.unwrap();
+
+            if headers_read {
+                if let Some(content_length) = content_length {
+                    body.push(byte);
+
+                    if body.len() >= content_length {
+                        success = true;
+                        break;
                     }
+                } else {
+                    info!("request was missing Content-Length header");
+                    break;
                 }
+            }
+
+            if byte == b'\r' {
+                continue;
+            } else if byte == b'\n' {
+                let str = String::from_utf8(line.clone()).unwrap();
+                line.clear();
+
+                if rtc_url_match {
+                    if str.starts_with("Content-Length: ") {
+                        content_length = str.replace("Content-Length: ", "").parse::<usize>().ok();
+                    } else if str.len() == 0 {
+                        headers_read = true;
+                    }
+                } else if str.starts_with(RTC_URL_PATH.get().unwrap()) {
+                    rtc_url_match = true;
+                }
+            } else {
+                line.push(byte);
             }
         }
 
         if success {
             success = false;
 
+            let mut lines = body.lines();
             let buf = RequestBuffer::new(&mut lines);
 
             match session_endpoint.http_session_request(buf).await {


### PR DESCRIPTION
Two critical fixes to make Safari behave. 

### set_remote_description
`set_remote_description_with_success_callback_and_failure_callback` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setRemoteDescription) and doesn't work in Safari. (readyState gets stuck at `Connecting`)
Switched it out with for `set_remote_description`. 

### Request buffering
Safari doesn't consistently send the full web request in one chunk. Mostly, it seems to send the headers first, and the body next. This meant the headers were read fine, `success` was set to true, but the body was empty, and thus the buffer sent to `http_session_request` was empty. 
This PR reads the Content-Length header and waits until the correct amount of bytes have been received before proceeding. 

Tested in latest versions of Chrome, Safari and Firefox on MacOS 12.2. 